### PR TITLE
ValueObjectListにdiff()メソッドを追加

### DIFF
--- a/src/ValueObjectList.php
+++ b/src/ValueObjectList.php
@@ -38,4 +38,13 @@ readonly class ValueObjectList extends ArrayList
     {
         return $this->mapStrict(static fn (IValueObject $e) => $e->equals($element) ? $element : $e);
     }
+
+    /**
+     * 他のコレクションと比較し、差分を取得する
+     * @param self<TValue> $other
+     */
+    public function diff(self $other): static
+    {
+        return $this->filter(static fn (IValueObject $e) => !$other->has($e));
+    }
 }

--- a/tests/Unit/ValueObjectListTest.php
+++ b/tests/Unit/ValueObjectListTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WizDevelop\PhpValueObject\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use WizDevelop\PhpValueObject\IValueObject;
+use WizDevelop\PhpValueObject\String\StringValue;
+use WizDevelop\PhpValueObject\Number\IntegerValue;
+use WizDevelop\PhpValueObject\ValueObjectList;
+
+#[TestDox('ValueObjectListクラスのテスト')]
+#[CoversClass(ValueObjectList::class)]
+final class ValueObjectListTest extends TestCase
+{
+    #[Test]
+    #[TestDox('has(): 値オブジェクトが存在する場合にtrueを返すこと')]
+    public function test_has_値オブジェクトが存在する場合にtrueを返すこと(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+            StringValue::from('cherry'),
+        ]);
+
+        // Act
+        $result = $list->has(StringValue::from('banana'));
+
+        // Assert
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    #[TestDox('has(): 値オブジェクトが存在しない場合にfalseを返すこと')]
+    public function test_has_値オブジェクトが存在しない場合にfalseを返すこと(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+            StringValue::from('cherry'),
+        ]);
+
+        // Act
+        $result = $list->has(StringValue::from('orange'));
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    #[TestDox('has(): 空のリストの場合にfalseを返すこと')]
+    public function test_has_空のリストの場合にfalseを返すこと(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([]);
+
+        // Act
+        $result = $list->has(StringValue::from('apple'));
+
+        // Assert
+        $this->assertFalse($result);
+    }
+
+    #[Test]
+    #[TestDox('remove(): 値オブジェクトを削除した新しいリストを返すこと')]
+    public function test_remove_値オブジェクトを削除した新しいリストを返すこと(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+            StringValue::from('cherry'),
+        ]);
+
+        // Act
+        $result = $list->remove(StringValue::from('banana'));
+
+        // Assert
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->has(StringValue::from('apple')));
+        $this->assertFalse($result->has(StringValue::from('banana')));
+        $this->assertTrue($result->has(StringValue::from('cherry')));
+    }
+
+    #[Test]
+    #[TestDox('remove(): 存在しない値オブジェクトを削除しても元のリストと同じになること')]
+    public function test_remove_存在しない値オブジェクトを削除しても元のリストと同じになること(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+        ]);
+
+        // Act
+        $result = $list->remove(StringValue::from('orange'));
+
+        // Assert
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->has(StringValue::from('apple')));
+        $this->assertTrue($result->has(StringValue::from('banana')));
+    }
+
+    #[Test]
+    #[TestDox('remove(): 複数の同じ値オブジェクトが存在する場合、すべて削除されること')]
+    public function test_remove_複数の同じ値オブジェクトが存在する場合すべて削除されること(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+            StringValue::from('apple'),
+            StringValue::from('cherry'),
+        ]);
+
+        // Act
+        $result = $list->remove(StringValue::from('apple'));
+
+        // Assert
+        $this->assertCount(2, $result);
+        $this->assertFalse($result->has(StringValue::from('apple')));
+        $this->assertTrue($result->has(StringValue::from('banana')));
+        $this->assertTrue($result->has(StringValue::from('cherry')));
+    }
+
+    #[Test]
+    #[TestDox('put(): 既存の値オブジェクトを新しいインスタンスで置換すること')]
+    public function test_put_既存の値オブジェクトを新しいインスタンスで置換すること(): void
+    {
+        // Arrange
+        $original20 = IntegerValue::from(20);
+        $list = ValueObjectList::from([
+            IntegerValue::from(10),
+            $original20,
+            IntegerValue::from(30),
+        ]);
+        $new20 = IntegerValue::from(20);
+
+        // Act
+        $result = $list->put($new20);
+
+        // Assert
+        $this->assertCount(3, $result);
+        $values = array_map(fn(IValueObject $v) => $v->value, $result->toArray());
+        $this->assertEquals([10, 20, 30], $values);
+        // 新しいインスタンスに置き換わっていることを確認
+        $this->assertNotSame($original20, $result->toArray()[1]);
+        $this->assertSame($new20, $result->toArray()[1]);
+    }
+
+    #[Test]
+    #[TestDox('put(): 複数の同じ値オブジェクトが存在する場合、すべて置換されること')]
+    public function test_put_複数の同じ値オブジェクトが存在する場合すべて置換されること(): void
+    {
+        // Arrange
+        $original10_1 = IntegerValue::from(10);
+        $original10_2 = IntegerValue::from(10);
+        $list = ValueObjectList::from([
+            $original10_1,
+            IntegerValue::from(20),
+            $original10_2,
+            IntegerValue::from(30),
+        ]);
+        $new10 = IntegerValue::from(10);
+
+        // Act
+        $result = $list->put($new10);
+
+        // Assert
+        $this->assertCount(4, $result);
+        $values = array_map(fn(IValueObject $v) => $v->value, $result->toArray());
+        $this->assertEquals([10, 20, 10, 30], $values);
+        // すべて新しいインスタンスに置き換わっていることを確認
+        $this->assertSame($new10, $result->toArray()[0]);
+        $this->assertSame($new10, $result->toArray()[2]);
+    }
+
+    #[Test]
+    #[TestDox('put(): 存在しない値オブジェクトの場合、リストは変更されないこと')]
+    public function test_put_存在しない値オブジェクトの場合リストは変更されないこと(): void
+    {
+        // Arrange
+        $list = ValueObjectList::from([
+            IntegerValue::from(10),
+            IntegerValue::from(20),
+            IntegerValue::from(30),
+        ]);
+
+        // Act
+        $result = $list->put(IntegerValue::from(40));
+
+        // Assert
+        $this->assertCount(3, $result);
+        $values = array_map(fn(IValueObject $v) => $v->value, $result->toArray());
+        $this->assertEquals([10, 20, 30], $values);
+    }
+
+    #[Test]
+    #[TestDox('diff(): 2つのリストの差分を返すこと')]
+    public function test_diff_2つのリストの差分を返すこと(): void
+    {
+        // Arrange
+        $list1 = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+            StringValue::from('cherry'),
+            StringValue::from('date'),
+        ]);
+        $list2 = ValueObjectList::from([
+            StringValue::from('banana'),
+            StringValue::from('date'),
+            StringValue::from('fig'),
+        ]);
+
+        // Act
+        $result = $list1->diff($list2);
+
+        // Assert
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->has(StringValue::from('apple')));
+        $this->assertTrue($result->has(StringValue::from('cherry')));
+        $this->assertFalse($result->has(StringValue::from('banana')));
+        $this->assertFalse($result->has(StringValue::from('date')));
+    }
+
+    #[Test]
+    #[TestDox('diff(): 空のリストとの差分は元のリストと同じになること')]
+    public function test_diff_空のリストとの差分は元のリストと同じになること(): void
+    {
+        // Arrange
+        $list1 = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+        ]);
+        $list2 = ValueObjectList::from([]);
+
+        // Act
+        $result = $list1->diff($list2);
+
+        // Assert
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->has(StringValue::from('apple')));
+        $this->assertTrue($result->has(StringValue::from('banana')));
+    }
+
+    #[Test]
+    #[TestDox('diff(): 同じリストとの差分は空のリストになること')]
+    public function test_diff_同じリストとの差分は空のリストになること(): void
+    {
+        // Arrange
+        $list1 = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+        ]);
+        $list2 = ValueObjectList::from([
+            StringValue::from('apple'),
+            StringValue::from('banana'),
+        ]);
+
+        // Act
+        $result = $list1->diff($list2);
+
+        // Assert
+        $this->assertCount(0, $result);
+    }
+
+    #[Test]
+    #[TestDox('diff(): 異なる型の値オブジェクトを含むリストでも正しく動作すること')]
+    public function test_diff_異なる型の値オブジェクトを含むリストでも正しく動作すること(): void
+    {
+        // Arrange
+        $list1 = ValueObjectList::from([
+            StringValue::from('apple'),
+            IntegerValue::from(10),
+            StringValue::from('banana'),
+        ]);
+        $list2 = ValueObjectList::from([
+            IntegerValue::from(10),
+            StringValue::from('cherry'),
+        ]);
+
+        // Act
+        $result = $list1->diff($list2);
+
+        // Assert
+        $this->assertCount(2, $result);
+        $this->assertTrue($result->has(StringValue::from('apple')));
+        $this->assertTrue($result->has(StringValue::from('banana')));
+        $this->assertFalse($result->has(IntegerValue::from(10)));
+    }
+}


### PR DESCRIPTION
## Summary
- ValueObjectListクラスに`diff()`メソッドを追加しました
- 他のコレクションとの差分を取得できる機能です
- 包括的なテストケースも実装しました

## 変更内容
- `diff(self $other): static` - 他のコレクションに含まれない要素のみを返すメソッド
- ValueObjectListの全メソッド（has, remove, put, diff）に対するテストを追加

## Test plan
- [x] `has()`: 値オブジェクトの存在確認
- [x] `remove()`: 値オブジェクトの削除（複数の同じ値も含む）
- [x] `put()`: 値オブジェクトの置換（新しいインスタンスへの置き換え）
- [x] `diff()`: コレクション間の差分取得（空のリスト、同じリスト、異なる型を含むリスト）

すべてのテストが成功しています。

🤖 Generated with [Claude Code](https://claude.ai/code)